### PR TITLE
Organize HDL modules by subsystem and add polar stubs

### DIFF
--- a/fifo/FIFO.sv
+++ b/fifo/FIFO.sv
@@ -1,0 +1,57 @@
+module FIFO #(parameter address_size = 4, parameter data_size = 8) (
+ input write_clk, read_clk,
+ input write_incr, read_incr,
+ input wreset_n, rreset_n,
+ input [data_size-1:0] write_data,
+ output [data_size-1:0] read_data,
+ output read_empty, write_full
+);
+ wire [address_size:0] write_pointer, read_pointer;
+ wire [address_size:0] write_pointer_s, read_pointer_s;
+ wire [address_size-1:0] write_address, read_address;
+
+ FIFO_Memory #(data_size, address_size) FIFO_inst (
+  .write_clk(write_clk),
+  .read_clk(read_clk),
+  .write_full(write_full),
+  .write_en(write_incr),
+  .write_data(write_data),
+  .read_data(read_data),
+  .write_address(write_address),
+  .read_address(read_address)
+ );
+
+ synchronous_write_read #(address_size) sync1 (
+  .read_clk(read_clk),
+  .rreset_n(rreset_n),
+  .write_pointer(write_pointer),
+  .write_pointer_s(write_pointer_s)
+ );
+
+ synchronous_read_write #(address_size) sync2 (
+  .write_clk(write_clk),
+  .wreset_n(wreset_n),
+  .read_pointer(read_pointer),
+  .read_pointer_s(read_pointer_s)
+ );
+
+ write_full #(address_size) full (
+  .write_clk(write_clk),
+  .wreset_n(wreset_n),
+  .write_incr(write_incr),
+  .read_pointer_s(read_pointer_s),
+  .write_pointer(write_pointer),
+  .write_address(write_address),
+  .write_full(write_full)
+ );
+
+ read_empty #(address_size) empty (
+  .read_clk(read_clk),
+  .rreset_n(rreset_n),
+  .read_incr(read_incr),
+  .write_pointer_s(write_pointer_s),
+  .read_pointer(read_pointer),
+  .read_address(read_address),
+  .read_empty(read_empty)
+ );
+endmodule

--- a/fifo/FIFO_Memory.sv
+++ b/fifo/FIFO_Memory.sv
@@ -1,0 +1,21 @@
+module FIFO_Memory #(parameter data_size = 8, parameter address_size = 4) (
+ input write_clk,
+ input read_clk,
+ input write_full,
+ input write_en,
+ input [data_size-1:0] write_data,
+ output reg [data_size-1:0] read_data,
+ input [address_size-1:0] write_address,
+ input [address_size-1:0] read_address
+);
+  reg [data_size-1:0] mem [0:(1<<address_size)-1];
+
+  always @(posedge write_clk) begin
+    if (write_en && !write_full)
+      mem[write_address] <= write_data;
+  end
+
+  always @(posedge read_clk) begin
+    read_data <= mem[read_address];
+  end
+endmodule

--- a/fifo/read_empty.sv
+++ b/fifo/read_empty.sv
@@ -1,0 +1,29 @@
+module read_empty #(parameter address_size = 4) (
+ input read_clk,
+ input rreset_n,
+ input read_incr,
+ input [address_size:0] write_pointer_s,
+ output reg [address_size:0] read_pointer,
+ output [address_size-1:0] read_address,
+ output reg read_empty
+);
+  assign read_address = read_pointer[address_size-1:0];
+  wire [address_size:0] read_pointer_next = read_pointer +
+      {{address_size{1'b0}}, (read_incr & ~read_empty)};
+
+  always @(posedge read_clk or negedge rreset_n) begin
+    if (!rreset_n) begin
+      read_pointer <= '0;
+    end else begin
+      read_pointer <= read_pointer_next;
+    end
+  end
+
+  always @(posedge read_clk or negedge rreset_n) begin
+    if (!rreset_n) begin
+      read_empty <= 1'b1;
+    end else begin
+      read_empty <= (read_pointer_next == write_pointer_s);
+    end
+  end
+endmodule

--- a/fifo/synchronous_read_write.sv
+++ b/fifo/synchronous_read_write.sv
@@ -1,0 +1,17 @@
+module synchronous_read_write #(parameter address_size = 4) (
+ input write_clk,
+ input wreset_n,
+ input [address_size:0] read_pointer,
+ output reg [address_size:0] read_pointer_s
+);
+  reg [address_size:0] sync_ff;
+  always @(posedge write_clk or negedge wreset_n) begin
+    if (!wreset_n) begin
+      sync_ff <= '0;
+      read_pointer_s <= '0;
+    end else begin
+      sync_ff <= read_pointer;
+      read_pointer_s <= sync_ff;
+    end
+  end
+endmodule

--- a/fifo/synchronous_write_read.sv
+++ b/fifo/synchronous_write_read.sv
@@ -1,0 +1,17 @@
+module synchronous_write_read #(parameter address_size = 4) (
+ input read_clk,
+ input rreset_n,
+ input [address_size:0] write_pointer,
+ output reg [address_size:0] write_pointer_s
+);
+  reg [address_size:0] sync_ff;
+  always @(posedge read_clk or negedge rreset_n) begin
+    if (!rreset_n) begin
+      sync_ff <= '0;
+      write_pointer_s <= '0;
+    end else begin
+      sync_ff <= write_pointer;
+      write_pointer_s <= sync_ff;
+    end
+  end
+endmodule

--- a/fifo/write_full.sv
+++ b/fifo/write_full.sv
@@ -1,0 +1,29 @@
+module write_full #(parameter address_size = 4) (
+ input write_clk,
+ input wreset_n,
+ input write_incr,
+ input [address_size:0] read_pointer_s,
+ output reg [address_size:0] write_pointer,
+ output [address_size-1:0] write_address,
+ output reg write_full
+);
+  assign write_address = write_pointer[address_size-1:0];
+  wire [address_size:0] write_pointer_next = write_pointer +
+      {{address_size{1'b0}}, (write_incr & ~write_full)};
+
+  always @(posedge write_clk or negedge wreset_n) begin
+    if (!wreset_n) begin
+      write_pointer <= '0;
+    end else begin
+      write_pointer <= write_pointer_next;
+    end
+  end
+
+  always @(posedge write_clk or negedge wreset_n) begin
+    if (!wreset_n) begin
+      write_full <= 1'b0;
+    end else begin
+      write_full <= (write_pointer_next == {~read_pointer_s[address_size], read_pointer_s[address_size-1:0]});
+    end
+  end
+endmodule

--- a/lint.sh
+++ b/lint.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+verilator --lint-only -Wall -Wno-MULTITOP \
+  turbo/rsc_lib.sv turbo/TurboEncoder.sv turbo/TurboDecoder.sv \
+  fifo/FIFO.sv fifo/FIFO_Memory.sv fifo/synchronous_write_read.sv fifo/synchronous_read_write.sv fifo/write_full.sv fifo/read_empty.sv \
+  polar/PolarEncoder.sv polar/PolarDecoder.sv

--- a/polar/PolarDecoder.sv
+++ b/polar/PolarDecoder.sv
@@ -1,0 +1,7 @@
+module PolarDecoder #(parameter DATA_WIDTH = 8) (
+    input  logic [DATA_WIDTH-1:0] data_in,
+    output logic [DATA_WIDTH-1:0] data_out
+);
+    // TODO: Implement polar decoding logic
+    assign data_out = data_in;
+endmodule

--- a/polar/PolarEncoder.sv
+++ b/polar/PolarEncoder.sv
@@ -1,0 +1,7 @@
+module PolarEncoder #(parameter DATA_WIDTH = 8) (
+    input  logic [DATA_WIDTH-1:0] data_in,
+    output logic [DATA_WIDTH-1:0] data_out
+);
+    // TODO: Implement polar encoding logic
+    assign data_out = data_in;
+endmodule

--- a/turbo/TurboDecoder.sv
+++ b/turbo/TurboDecoder.sv
@@ -1,0 +1,25 @@
+module TurboDecoder (
+    input  logic clk,
+    input  logic rst_n,
+    input  logic bit_in,
+    input  int   index_in,
+    input  int   size,
+    output logic parity_ref,
+    output int   index_out
+);
+    import rsc_lib::*;
+
+    logic [1:0] state;
+    logic [1:0] next_state;
+
+    always_ff @(posedge clk or negedge rst_n) begin
+        if (!rst_n) begin
+            state <= '0;
+        end else begin
+            rsc_encode(bit_in, state, parity_ref, next_state);
+            state <= next_state;
+        end
+    end
+
+    assign index_out = interleave_index(index_in, size);
+endmodule

--- a/turbo/TurboEncoder.sv
+++ b/turbo/TurboEncoder.sv
@@ -1,0 +1,25 @@
+module TurboEncoder (
+    input  logic clk,
+    input  logic rst_n,
+    input  logic bit_in,
+    input  int   index_in,
+    input  int   size,
+    output logic parity_out,
+    output int   index_out
+);
+    import rsc_lib::*;
+
+    logic [1:0] state;
+    logic [1:0] next_state;
+
+    always_ff @(posedge clk or negedge rst_n) begin
+        if (!rst_n) begin
+            state <= '0;
+        end else begin
+            rsc_encode(bit_in, state, parity_out, next_state);
+            state <= next_state;
+        end
+    end
+
+    assign index_out = interleave_index(index_in, size);
+endmodule

--- a/turbo/rsc_lib.sv
+++ b/turbo/rsc_lib.sv
@@ -1,0 +1,20 @@
+package rsc_lib;
+
+  function automatic void rsc_encode(
+      input  logic       bit_in,
+      input  logic [1:0] state_in,
+      output logic       parity_out,
+      output logic [1:0] state_out
+  );
+      parity_out = bit_in ^ state_in[0] ^ state_in[1];
+      state_out  = {bit_in, state_in[0]};
+  endfunction
+
+  function automatic int interleave_index(
+      input int idx,
+      input int size
+  );
+      interleave_index = (idx * 3) % size;
+  endfunction
+
+endpackage : rsc_lib


### PR DESCRIPTION
## Summary
- move FIFO and turbo SystemVerilog sources into `fifo` and `turbo` directories
- introduce `polar` directory with initial `PolarEncoder` and `PolarDecoder` modules
- update lint script to cover new directory structure

## Testing
- `apt-get update`
- `apt-get install -y verilator`
- `./lint.sh`


------
https://chatgpt.com/codex/tasks/task_e_68987a0053688320877f03ec0b0a9ca9