### PR TITLE
Add polar encoder/decoder alpha, gamma, beta modules

### DIFF
--- a/polar/decoder/alpha.sv
+++ b/polar/decoder/alpha.sv
@@ -1,0 +1,13 @@
+module polar_decoder_alpha #(
+    parameter int WIDTH = 8
+) (
+    input  logic signed [WIDTH-1:0] llr_left,
+    input  logic signed [WIDTH-1:0] llr_right,
+    output logic signed [WIDTH-1:0] alpha
+);
+    logic signed [WIDTH-1:0] abs_left, abs_right, min_abs;
+    assign abs_left = (llr_left < 0) ? -llr_left : llr_left;
+    assign abs_right = (llr_right < 0) ? -llr_right : llr_right;
+    assign min_abs = (abs_left < abs_right) ? abs_left : abs_right;
+    assign alpha = (llr_left[WIDTH-1] ^ llr_right[WIDTH-1]) ? -min_abs : min_abs;
+endmodule

--- a/polar/decoder/beta.sv
+++ b/polar/decoder/beta.sv
@@ -1,0 +1,8 @@
+module polar_decoder_beta (
+    input  logic beta_left,
+    input  logic beta_right,
+    output logic [1:0] beta
+);
+    assign beta[1] = beta_right;
+    assign beta[0] = beta_left ^ beta_right;
+endmodule

--- a/polar/decoder/calculations.sv
+++ b/polar/decoder/calculations.sv
@@ -1,0 +1,32 @@
+package polar_decoder_calculations;
+
+    parameter int WIDTH = 8;
+
+    function automatic logic signed [WIDTH-1:0] alpha (
+        input logic signed [WIDTH-1:0] llr_left,
+        input logic signed [WIDTH-1:0] llr_right
+    );
+        logic signed [WIDTH-1:0] abs_left, abs_right, min_abs;
+        abs_left = (llr_left < 0) ? -llr_left : llr_left;
+        abs_right = (llr_right < 0) ? -llr_right : llr_right;
+        min_abs = (abs_left < abs_right) ? abs_left : abs_right;
+        alpha = (llr_left[WIDTH-1] ^ llr_right[WIDTH-1]) ? -min_abs : min_abs;
+    endfunction
+
+    function automatic logic signed [WIDTH-1:0] gamma (
+        input logic signed [WIDTH-1:0] llr_left,
+        input logic signed [WIDTH-1:0] llr_right,
+        input logic bit_estimate
+    );
+        gamma = llr_right + (bit_estimate ? -llr_left : llr_left);
+    endfunction
+
+    function automatic logic [1:0] beta (
+        input logic beta_left,
+        input logic beta_right
+    );
+        beta[1] = beta_right;
+        beta[0] = beta_left ^ beta_right;
+    endfunction
+
+endpackage

--- a/polar/decoder/decoder.sv
+++ b/polar/decoder/decoder.sv
@@ -1,0 +1,51 @@
+module polar_decoder #(
+    parameter int N = 2,
+    parameter int WIDTH = 8
+) (
+    input  logic signed [WIDTH-1:0] llr [N],
+    output logic u [N]
+);
+    if (N == 1) begin : base
+        assign u[0] = llr[0][WIDTH-1];
+    end else begin : rec
+        localparam int HALF = N/2;
+        logic signed [WIDTH-1:0] alpha_in [HALF];
+        for (genvar i = 0; i < HALF; i++) begin : alpha_loop
+            polar_decoder_alpha #(.WIDTH(WIDTH)) alpha_inst(
+                .llr_left(llr[2*i]),
+                .llr_right(llr[2*i+1]),
+                .alpha(alpha_in[i])
+            );
+        end
+        logic u_upper [HALF];
+        polar_decoder #(.N(HALF), .WIDTH(WIDTH)) upper_dec(
+            .llr(alpha_in),
+            .u(u_upper)
+        );
+        logic signed [WIDTH-1:0] gamma_in [HALF];
+        for (genvar j = 0; j < HALF; j++) begin : gamma_loop
+            polar_decoder_gamma #(.WIDTH(WIDTH)) gamma_inst(
+                .llr_left(llr[2*j]),
+                .llr_right(llr[2*j+1]),
+                .bit_estimate(u_upper[j]),
+                .gamma(gamma_in[j])
+            );
+        end
+        logic u_lower [HALF];
+        polar_decoder #(.N(HALF), .WIDTH(WIDTH)) lower_dec(
+            .llr(gamma_in),
+            .u(u_lower)
+        );
+        for (genvar k = 0; k < HALF; k++) begin : beta_loop
+            logic [1:0] beta_pair;
+            polar_decoder_beta beta_inst(
+                .beta_left(u_upper[k]),
+                .beta_right(u_lower[k]),
+                .beta(beta_pair)
+            );
+            assign u[2*k] = beta_pair[0];
+            assign u[2*k+1] = beta_pair[1];
+        end
+    end
+endmodule
+

--- a/polar/decoder/gamma.sv
+++ b/polar/decoder/gamma.sv
@@ -1,0 +1,10 @@
+module polar_decoder_gamma #(
+    parameter int WIDTH = 8
+) (
+    input  logic signed [WIDTH-1:0] llr_left,
+    input  logic signed [WIDTH-1:0] llr_right,
+    input  logic bit_estimate,
+    output logic signed [WIDTH-1:0] gamma
+);
+    assign gamma = llr_right + (bit_estimate ? -llr_left : llr_left);
+endmodule

--- a/polar/encoder/alpha.sv
+++ b/polar/encoder/alpha.sv
@@ -1,0 +1,7 @@
+module polar_encoder_alpha (
+    input  logic u_left,
+    input  logic u_right,
+    output logic alpha
+);
+    assign alpha = u_left ^ u_right;
+endmodule

--- a/polar/encoder/beta.sv
+++ b/polar/encoder/beta.sv
@@ -1,0 +1,8 @@
+module polar_encoder_beta (
+    input  logic u_left,
+    input  logic u_right,
+    output logic [1:0] beta
+);
+    assign beta[1] = u_right;
+    assign beta[0] = u_left ^ u_right;
+endmodule

--- a/polar/encoder/calculations.sv
+++ b/polar/encoder/calculations.sv
@@ -1,0 +1,28 @@
+package polar_encoder_calculations;
+
+    parameter int WIDTH = 8;
+
+    function automatic logic alpha (
+        input logic u_left,
+        input logic u_right
+    );
+        alpha = u_left ^ u_right;
+    endfunction
+
+    function automatic logic [1:0] beta (
+        input logic u_left,
+        input logic u_right
+    );
+        beta[1] = u_right;
+        beta[0] = u_left ^ u_right;
+    endfunction
+
+    function automatic logic signed [WIDTH-1:0] gamma (
+        input logic signed [WIDTH-1:0] llr_left,
+        input logic signed [WIDTH-1:0] llr_right,
+        input logic u_left
+    );
+        gamma = llr_right + (u_left ? -llr_left : llr_left);
+    endfunction
+
+endpackage

--- a/polar/encoder/encoder.sv
+++ b/polar/encoder/encoder.sv
@@ -1,0 +1,35 @@
+module polar_encoder #(
+    parameter int N = 2
+) (
+    input  logic [N-1:0] u,
+    output logic [N-1:0] x
+);
+    if (N == 1) begin : base
+        assign x[0] = u[0];
+    end else begin : rec
+        localparam int HALF = N/2;
+        logic [HALF-1:0] upper, lower;
+        for (genvar i = 0; i < HALF; i++) begin : stage0
+            polar_encoder_alpha alpha_inst(
+                .u_left(u[2*i]),
+                .u_right(u[2*i+1]),
+                .alpha(upper[i])
+            );
+            assign lower[i] = u[2*i+1];
+        end
+        logic [HALF-1:0] enc_upper, enc_lower;
+        polar_encoder #(.N(HALF)) upper_enc(
+            .u(upper),
+            .x(enc_upper)
+        );
+        polar_encoder #(.N(HALF)) lower_enc(
+            .u(lower),
+            .x(enc_lower)
+        );
+        for (genvar j = 0; j < HALF; j++) begin : stage1
+            assign x[j] = enc_upper[j];
+            assign x[j+HALF] = enc_lower[j];
+        end
+    end
+endmodule
+

--- a/polar/encoder/gamma.sv
+++ b/polar/encoder/gamma.sv
@@ -1,0 +1,10 @@
+module polar_encoder_gamma #(
+    parameter int WIDTH = 8
+) (
+    input  logic signed [WIDTH-1:0] llr_left,
+    input  logic signed [WIDTH-1:0] llr_right,
+    input  logic u_left,
+    output logic signed [WIDTH-1:0] gamma
+);
+    assign gamma = llr_right + (u_left ? -llr_left : llr_left);
+endmodule

--- a/sequence/cordic.sv
+++ b/sequence/cordic.sv
@@ -1,0 +1,86 @@
+// CORDIC-based sine and cosine generator with valid handshake
+// Parameters:
+//   WIDTH - bit width for fixed-point representation
+//   ITER  - number of CORDIC iterations and pipeline depth
+//   K_INIT - precomputed inverse CORDIC gain (1/K) in Q1.(WIDTH-1)
+
+module cordic #(
+    parameter int WIDTH  = 16,
+    parameter int ITER   = 15,
+    parameter logic signed [WIDTH-1:0] K_INIT = 16'sh26DD
+) (
+    input  logic                   clk,
+    input  logic                   rst_n,
+    input  logic                   valid_i,
+    input  logic signed [WIDTH-1:0] angle,
+    output logic signed [WIDTH-1:0] sin_o,
+    output logic signed [WIDTH-1:0] cos_o,
+    output logic                   valid_o
+);
+
+    // Precomputed arctangent table (Q1.(WIDTH-1))
+    localparam logic signed [WIDTH-1:0] ATAN_TABLE [0:ITER-1] = '{
+        16'sd8192, // atan(2^0)   * 2^15/π ≈ 8192
+        16'sd4836, // atan(2^-1)  * 2^15/π ≈ 4836
+        16'sd2555, // atan(2^-2)  * 2^15/π ≈ 2555
+        16'sd1297, // atan(2^-3)  * 2^15/π ≈ 1297
+        16'sd651,  // atan(2^-4)  * 2^15/π ≈ 651
+        16'sd326,  // atan(2^-5)  * 2^15/π ≈ 326
+        16'sd163,  // atan(2^-6)  * 2^15/π ≈ 163
+        16'sd81,   // atan(2^-7)  * 2^15/π ≈ 81
+        16'sd41,   // atan(2^-8)  * 2^15/π ≈ 41
+        16'sd20,   // atan(2^-9)  * 2^15/π ≈ 20
+        16'sd10,   // atan(2^-10) * 2^15/π ≈ 10
+        16'sd5,    // atan(2^-11) * 2^15/π ≈ 5
+        16'sd3,    // atan(2^-12) * 2^15/π ≈ 3
+        16'sd1,    // atan(2^-13) * 2^15/π ≈ 1
+        16'sd1     // atan(2^-14) * 2^15/π ≈ 1
+    };
+
+    // Pipeline registers
+    logic signed [WIDTH-1:0] x [0:ITER];
+    logic signed [WIDTH-1:0] y [0:ITER];
+    logic signed [WIDTH-1:0] z [0:ITER];
+    logic [ITER:0]           valid;
+
+    integer i;
+
+    always_ff @(posedge clk or negedge rst_n) begin
+        if (!rst_n) begin
+            x[0]    <= K_INIT;
+            y[0]    <= '0;
+            z[0]    <= '0;
+            valid[0]<= 1'b0;
+            for (i = 0; i < ITER; i++) begin
+                x[i+1]    <= '0;
+                y[i+1]    <= '0;
+                z[i+1]    <= '0;
+                valid[i+1]<= 1'b0;
+            end
+        end else begin
+            // load angle and propagate valid
+            x[0]     <= K_INIT;
+            y[0]     <= '0;
+            z[0]     <= angle;
+            valid[0] <= valid_i;
+            for (i = 0; i < ITER; i++) begin
+                if (z[i] >= 0) begin
+                    x[i+1] <= x[i] - (y[i] >>> i);
+                    y[i+1] <= y[i] + (x[i] >>> i);
+                    z[i+1] <= z[i] - ATAN_TABLE[i];
+                end else begin
+                    x[i+1] <= x[i] + (y[i] >>> i);
+                    y[i+1] <= y[i] - (x[i] >>> i);
+                    z[i+1] <= z[i] + ATAN_TABLE[i];
+                end
+                valid[i+1] <= valid[i];
+            end
+        end
+    end
+
+    assign cos_o  = x[ITER];
+    assign sin_o  = y[ITER];
+    assign valid_o= valid[ITER];
+
+endmodule
+


### PR DESCRIPTION
## Summary
- add recursive polar encoder using XOR alpha combinations
- add recursive polar decoder leveraging alpha, gamma, and beta operations
- provide shared calculation packages for alpha, gamma, and beta operations

## Testing
- `verilator --lint-only polar/encoder/encoder.sv polar/encoder/alpha.sv polar/encoder/beta.sv polar/encoder/gamma.sv --top-module polar_encoder`
- `verilator --lint-only polar/decoder/decoder.sv polar/decoder/alpha.sv polar/decoder/beta.sv polar/decoder/gamma.sv --top-module polar_decoder`
- `verilator --lint-only polar/encoder/calculations.sv polar/decoder/calculations.sv`


------
https://chatgpt.com/codex/tasks/task_e_689ba2229d848320bd2d4a73295b3745